### PR TITLE
Fix missing drive cell models for portable cells

### DIFF
--- a/src/main/java/es/degrassi/appexp/client/AppliedExperiencedClient.java
+++ b/src/main/java/es/degrassi/appexp/client/AppliedExperiencedClient.java
@@ -45,12 +45,12 @@ public class AppliedExperiencedClient {
   private void initializeModels(FMLClientSetupEvent event) {
     event.enqueueWork(() -> {
       var prefix = "block/drive/cells/";
-      AExpItems.getCells().forEach(cell ->
-          StorageCellModels.registerModel(cell.get(), id(prefix + cell.id().getPath()))
-      );
-      AExpItems.getPortables().forEach(cell ->
-          StorageCellModels.registerModel(cell.get(), id(prefix + cell.id().getPath()))
-      );
+
+      for (var i = 0; i < AExpItems.getCells().size(); i++) {
+        var cell = AExpItems.getCells().get(i);
+        StorageCellModels.registerModel(cell.get(), id(prefix + cell.id().getPath()));
+        StorageCellModels.registerModel(AExpItems.getPortables().get(i).get(), id(prefix + cell.id().getPath()));
+      }
     });
   }
 


### PR DESCRIPTION
Forgotten in PR #2 as it was only noticed some time later. Up until now, portable cells would have expected dedicated drive cell models for portables which would not actually exist. This PR simply reuses the same drive cell models for portables as for standard cells.